### PR TITLE
Исправил формирование наименований генерируемых классов под windows

### DIFF
--- a/src/main/kotlin/jsm/java/TypeName.kt
+++ b/src/main/kotlin/jsm/java/TypeName.kt
@@ -1,6 +1,7 @@
 package jsm.java
 
 import jsm.*
+import java.io.File
 
 fun toJavaClassName(basePackage: String, typedFragment: TypedFragment, suffix: String? = null): String {
     val typeName = toTypeName(typedFragment, suffix)
@@ -21,7 +22,7 @@ fun toTypeName(typedFragment: TypedFragment, suffix: String? = null): TypeName {
     do {
         val fragmentReference = currentFragment.fragment.reference
         if (fragmentReference.fragmentPath.isEmpty()) {
-            val lastName = fragmentReference.filePath.split("/").last()
+            val lastName = fragmentReference.filePath.split(File.separator).last()
             val dotIndex = lastName.indexOf('.')
             val namePart = if (dotIndex == -1) lastName else lastName.substring(0, dotIndex)
             nameParts.add(namePart)
@@ -44,7 +45,7 @@ fun toTypeName(typedFragment: TypedFragment, suffix: String? = null): TypeName {
 
     nameParts.reverse()
     val simpleName = toUpperCamelCase(*(nameParts + suffix).filterNotNull().toTypedArray())
-    val pathComponents = typedFragment.fragment.reference.filePath.split('/')
+    val pathComponents = typedFragment.fragment.reference.filePath.split(File.separator)
     val namespace = toNamespace(pathComponents)
     return TypeName(namespace, simpleName)
 }
@@ -116,7 +117,7 @@ fun toCamelCase(firstUpper: Boolean, vararg parts: String): String {
 }
 
 fun getFilePath(className: String): String {
-    return "${className.replace('.', '/')}.java"
+    return "${className.replace('.', File.separatorChar)}.java"
 }
 
 fun getPackage(className: String): String {

--- a/src/main/kotlin/jsm/typescript/axios/AxiosClientWriter.kt
+++ b/src/main/kotlin/jsm/typescript/axios/AxiosClientWriter.kt
@@ -3,6 +3,7 @@ package jsm.typescript.axios
 import jsm.*
 import jsm.java.toLowerCamelCase
 import jsm.typescript.*
+import java.io.File
 import java.lang.StringBuilder
 
 private fun axiosMethod(operationType: OperationType) = when (operationType) {
@@ -80,7 +81,7 @@ class AxiosClientWriter(val basePackage: String) : Writer<OpenApiSchema> {
                     )
                 }
             }
-            val schemaFileName = openApiSchema.fragment.reference.filePath.split("/").last()
+            val schemaFileName = openApiSchema.fragment.reference.filePath.split(File.separator).last()
             val schemaName = schemaFileName.substring(0, schemaFileName.lastIndexOf('.'))
             val outputFileName = "${toLowerCamelCase(schemaName)}.ts"
 

--- a/src/test/kotlin/jsm/TestUtils.kt
+++ b/src/test/kotlin/jsm/TestUtils.kt
@@ -10,6 +10,7 @@ import org.eclipse.jgit.lib.TreeFormatter
 import org.eclipse.jgit.revwalk.RevWalk
 import org.junit.jupiter.api.Assertions.fail
 import java.io.ByteArrayOutputStream
+import java.io.File
 
 sealed class FileTreeNode
 
@@ -17,7 +18,7 @@ class FileNode(val content: String) : FileTreeNode()
 
 class DirectoryNode(val children: MutableMap<String, FileTreeNode>) : FileTreeNode() {
     fun addFile(path: String, content: String) {
-        addFile(path.split("/"), content)
+        addFile(path.split(File.separator), content)
     }
 
     private fun addFile(path: List<String>, content: String) {
@@ -48,7 +49,9 @@ class TreeConverter(private val inserter: ObjectInserter, private val revWalk: R
         directoryNode.children.forEach { (name, child) ->
             when (child) {
                 is FileNode -> {
-                    val fileBlobId = inserter.insert(OBJ_BLOB, child.content.toByteArray())
+                    val fileBlobId = inserter.insert(OBJ_BLOB, child.content
+                            .replace("\r\n", "\n")
+                            .toByteArray())
                     treeFormatter.append(name, revWalk.lookupBlob(fileBlobId))
                 }
                 is DirectoryNode -> {


### PR DESCRIPTION
из за различий в разделителе на разных платформах, неправильно формировались имена типов на windows
Пример
private ru.sbrf.ufs.sbbol.dul.emulator.Schemas\common\account p3; // account
private ru.sbrf.ufs.sbbol.dul.emulator.Schemas\common\account p4; // accountReturn
private ru.sbrf.ufs.sbbol.dul.emulator.Schemas\common\specialCondition p5; // specialCondition
private ru.sbrf.ufs.sbbol.dul.emulator.Schemas\common\docAmount p6; // depositAmount 

соответственно сгенерированный код не компилировался